### PR TITLE
Use EnumDecl names when available

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -201,7 +201,7 @@ end
 ################################################################################
 
 function wrap(buf::IO, cursor::EnumDecl; usename="")
-    if (usename == "")
+    if (usename == "" && (usename = name(cursor)) == "")
         usename = name_anon()
     end
     enumname = usename


### PR DESCRIPTION
`libcudart.jl` was typing arguments using the names of `enum` types, but in `libcudart_h.jl` I was getting stuff like this:

```
# begin enum ANONYMOUS_1
typealias ANONYMOUS_1 Uint32  # should have been cudaRoundMode
const cudaRoundNearest = 0
```
