### PR TITLE
Skip MacroDefinition output when we don't lex all tokens

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -465,12 +465,16 @@ function wrap(context::WrapContext, strm::IO, md::cindex.MacroDefinition)
     if(tokens[2].text == "(")
         exprn,pos = lex_exprn(tokens, 3)
         if (pos != endof(tokens) || tokens[pos].text != ")")
-            print(strm, "# Skipping MacroDefinition: ", join([c.text for c in tokens]), "\n")
+            print(strm, "# Skipping MacroDefinition: ", join([c.text for c in tokens], " "), "\n")
             return
         end
         exprn = "(" * exprn * ")"
     else
         (exprn,pos) = lex_exprn(tokens, 2)
+        if (pos != endof(tokens))
+            print(strm, "# Skipping MacroDefinition: ", join([c.text for c in tokens], " "), "\n")
+            return
+        end
     end
     exprn = replace(exprn, "\$", "\\\$")
     print(strm, "const " * string(tokens[1].text) * " = " * exprn * "\n")


### PR DESCRIPTION
Some macro definitions were slipping through here.  E.g., 

``` c
#define AV_CH_WIDE_LEFT UINT64_C(0x0000000080000000)
```

was output as 

``` julia
const AV_CH_WIDE_LEFT=UINT64_C
```

A better fix would probably be to parse and understand the macro, but that's probably a little ways off...
