### PR TITLE
Add a `zero` function for each `immutable Array_<type>_<num>`

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -231,6 +231,14 @@ function repr_jl(t::ConstantArray)
             push!(b.args, Expr(:(::), symbol("d$i"), repr))
         end
         push!(buf, e)
+
+        # Add zero function for this type
+        b = :($(symbol(typename))())
+        for i = 1:arrsize
+            push!(b.args, :(zero($repr)))
+        end
+        zero_call = :(zero(::Type{$(symbol(typename))}) = $b)
+        push!(buf, zero_call)
     end
     push!(context.cache_wrapped, typename)
     return symbol(typename)


### PR DESCRIPTION
For large objects, this is an easy initializer.

I've found this useful in wrapping libav, but it could be optional, or not generally needed or wanted, so feedback welcome.
