### PR TITLE
Don't require rewriter to mutate buffer

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -128,7 +128,7 @@ function Base.run(wc::WrapContext, generate_template=true)
         end
 
         # apply user-supplied transformation
-        wc.rewriter(ctx.api_buffer)
+        ctx.api_buffer = wc.rewriter(ctx.api_buffer)
 
         # write output
         out_file = wc.header_outputfile(header)


### PR DESCRIPTION
This follows how the transformation is applied for the common file: https://github.com/JuliaInterop/Clang.jl/blob/c2c0ea3a6068fe2de40957d31a189691e7cfb4bf/src/compat.jl#L147

I was returning a new buffer in my rewriter and got confused it would only do anything for the common file.