### PR TITLE
Allow strings in DefaultContext's api_buffer

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -7,14 +7,14 @@ mutable struct DefaultContext <: AbstractContext
     libname::String
     force_name::String
     common_buffer::OrderedDict{Symbol,ExprUnit}
-    api_buffer::Vector{Expr}
+    api_buffer::Vector
     cursor_stack::Vector{CLCursor}
     children::Vector{CLCursor}
     children_index::Int
     anonymous_counter::Int
 end
 DefaultContext(index::Index) = DefaultContext(index, TranslationUnit[], Dict{String,Bool}(),
-                                              "libxxx", "", OrderedDict{Symbol,ExprUnit}(), Expr[],
+                                              "libxxx", "", OrderedDict{Symbol,ExprUnit}(), [],
                                               CLCursor[], CLCursor[], -1, 0)
 DefaultContext(diagnostic::Bool=true) = DefaultContext(Index(diagnostic))
 


### PR DESCRIPTION
In the `common` case, `dump_to_buffer` creates a `Vector{Any}` buffer: https://github.com/JuliaInterop/Clang.jl/blob/c2c0ea3a6068fe2de40957d31a189691e7cfb4bf/src/expr_unit.jl#L66
Which is then used to mix `Expr` and `String`, using the latter for comments in `print_buffer`: https://github.com/JuliaInterop/Clang.jl/blob/c2c0ea3a6068fe2de40957d31a189691e7cfb4bf/src/expr_unit.jl#L27

Unfortunately I cannot use this in `api_buffer` since it is set to `Vector{Expr}` only. With this tweak, I can let my rewriter function insert docstrings that will look the way I want. I know I can put docstr + function together in an expression, but that prints ugly with the at-doc macro.

If you prefer I can also just make it `Vector{Union{Expr, String}}`