### PR TITLE
Remove warnings for `CLLastPreprocessing` and `CLMacroInstantiation` cursors

### DIFF
--- a/src/wrap_c.jl
+++ b/src/wrap_c.jl
@@ -443,3 +443,8 @@ function wrap!(ctx::AbstractContext, cursor::CLCursor)
     @warn "not wrapping $(cursor)"
     return ctx
 end
+
+function wrap!(ctx::AbstractContext, cursor::Union{CLLastPreprocessing,CLMacroInstantiation})
+    @debug "not wrapping $(cursor)"
+    return ctx
+end


### PR DESCRIPTION
It looks like many new users are confused by those warnings. Since almost all of them can be safely ignored, I think it's better to print them as debug info.