### PR TITLE
add ".." to fix `LIBCLANG_INCLUDE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ further details.
 using Clang
 using Clang.LibClang.Clang_jll
 
-const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "include", "clang-c") |> normpath
+const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "..", "include", "clang-c") |> normpath
 const LIBCLANG_HEADERS = [joinpath(LIBCLANG_INCLUDE, header) for header in readdir(LIBCLANG_INCLUDE) if endswith(header, ".h")]
 
 # create a work context

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,7 @@ further details.
 using Clang
 using Clang_jll # `pkg> activate Clang`
 
-const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "include", "clang-c") |> normpath
+const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "..", "include", "clang-c") |> normpath
 const LIBCLANG_HEADERS = [joinpath(LIBCLANG_INCLUDE, header) for header in readdir(LIBCLANG_INCLUDE) if endswith(header, ".h")]
 
 # create a work context

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ using Clang
 using Clang_jll # `pkg> activate Clang`
 
 # LIBCLANG_HEADERS are those headers to be wrapped.
-const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "include", "clang-c") |> normpath
+const LIBCLANG_INCLUDE = joinpath(dirname(Clang_jll.libclang_path), "..", "include", "clang-c") |> normpath
 const LIBCLANG_HEADERS = [joinpath(LIBCLANG_INCLUDE, header) for header in readdir(LIBCLANG_INCLUDE) if endswith(header, ".h")]
 
 wc = init(; headers = LIBCLANG_HEADERS,


### PR DESCRIPTION
This PR fixes `LIBCLANG_INCLUDE` in `docs/src/index.md`