### PR TITLE
Add pass for generating API methods with a function pointer parameter

### DIFF
--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -116,6 +116,10 @@ function create_context(headers::Vector, args::Vector=String[], options::Dict=Di
         push!(ctx.passes, TweakMutability())
     end
 
+    if get(general_options, "add_fptr_methods", false)
+        push!(ctx.passes, AddFPtrMethods())
+    end
+
     # support old behavior
     api_file = get(general_options, "output_api_file_path", "")
     common_file = get(general_options, "output_common_file_path", "")

--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -112,12 +112,11 @@ function create_context(headers::Vector, args::Vector=String[], options::Dict=Di
     push!(ctx.passes, Codegen())
     push!(ctx.passes, CodegenMacro())
     # push!(ctx.passes, CodegenPostprocessing())
-    if get(general_options, "auto_mutability", false)
-        push!(ctx.passes, TweakMutability())
-    end
-
     if get(general_options, "add_fptr_methods", false)
         push!(ctx.passes, AddFPtrMethods())
+    end
+    if get(general_options, "auto_mutability", false)
+        push!(ctx.passes, TweakMutability())
     end
 
     # support old behavior

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -756,6 +756,51 @@ function (x::TweakMutability)(dag::ExprDAG, options::Dict)
     return dag
 end
 
+"""
+    AddFPtrMethods <: AbstractPass
+This pass adds a method definition for each function prototype method which `ccall`s into a library.
+
+The generated method allows the use of a function pointer to `ccall` into directly, instead
+of relying on a library to give the pointer via a symbol look up. This is useful for libraries that
+use runtime loaders to dynamically resolve function pointers for API calls.
+"""
+struct AddFPtrMethods <: AbstractPass end
+
+function (::AddFPtrMethods)(dag::ExprDAG, options::Dict)
+    codegen_options = get(options, "codegen", Dict())
+    use_ccall_macro = get(codegen_options, "use_ccall_macro", false)
+    for node in dag.nodes
+        node.type isa FunctionProto || continue
+        for _ex in copy(node.exprs)
+            ex = deepcopy(_ex)
+            Base.is_expr(ex, :function) || continue
+            if Base.is_expr(ex.args[1], :where)
+                call = ex.args[1].args[1]
+            else
+                call = ex.args[1]
+            end
+            push!(call.args, :fptr)
+            body_idx = findfirst(x -> Base.is_expr(x, :block), ex.args)
+            body = ex.args[body_idx]
+            idx = if use_ccall_macro
+                findfirst(x -> Base.is_expr(x, :macrocall) && x.args[1] == Symbol("@ccall"), body.args)
+            else
+                findfirst(x -> Base.is_expr(x, :call) && x.args[1] == :ccall, body.args)
+            end
+            !isnothing(idx) || continue
+            stmt = body.args[idx]
+            if use_ccall_macro
+                assert_idx = findfirst(x -> Base.is_expr(x, :(::)), stmt.args)
+                call_idx = findfirst(x -> Base.is_expr(x, :call), stmt.args[assert_idx].args)
+                stmt.args[assert_idx].args[call_idx].args[1] = Expr(:$, :fptr)
+            else
+                stmt.args[2] = :fptr
+            end
+            push!(node.exprs, ex)
+        end
+    end
+end
+
 const DEFAULT_AUDIT_FUNCTIONS = [
     audit_library_name,
     sanity_check,


### PR DESCRIPTION
Following from JuliaGPU/VulkanCore.jl#44, here is a pass for adding extra methods to API functions that `ccall` into libraries, exposing a function pointer argument for short-circuiting the library symbol lookup.

I tested it on VulkanCore.jl, both with `use_ccall_macro` turned on and off, and it seems to work as expected (update PR to come after this is merged). The test infrastructure did not seem to provide a handy way to test the behavior of this specific pass.

I made the inclusion of the pass to be a general option named "add_fptr_methods", feel free to suggest another name if that is not clear.