### PR TITLE
Generate constructors for union and struct records

### DIFF
--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -382,7 +382,6 @@ function emit_constructor!(dag, node::ExprNode{<:StructLayout}, options)
 
     rm_line_num_node!(body)
 
-    push!(body.args, )
     func = Expr(:function, Expr(:call, sym, (:($fsym::$ty) for (fsym, ty) in zip(fsyms, tys))...), body)
     push!(node.exprs, func)
 end


### PR DESCRIPTION
Implements constructors for union structs, as discussed in #304, and also for struct records (in a very similar way).

I am unsure about struct records since fields may overlap, so any suggestions are welcome.

Because we use `setproperty!` on the pointer, which does most of the layout logic, I think this takes care of all possibilities including unions with offsets/different sizes, records with and without byte-aligned fields, records with unions, unions with records.

See below for a few examples of what the generated constructor looks like.

Union struct:
```julia
# definition
struct VkClearValue
    data::NTuple{16, UInt8}
end

# to see the layout
function Base.getproperty(x::Ptr{VkClearValue}, f::Symbol)
    f === :color && return Ptr{VkClearColorValue}(x + 0)
    f === :depthStencil && return Ptr{VkClearDepthStencilValue}(x + 0)
    return getfield(x, f)
end

# generated code from this PR

const __U_VkClearValue = Union{VkClearColorValue, VkClearDepthStencilValue}

function VkClearValue(val::__U_VkClearValue)
    ref = Ref{VkClearValue}()
    ptr = Base.unsafe_convert(Ptr{VkClearValue}, ref)
    if val isa VkClearColorValue
        ptr.color = val
    elseif val isa VkClearDepthStencilValue
        ptr.depthStencil = val
    end
    ref[]
end
```

Struct record:

```julia
# definition
struct VkAccelerationStructureInstanceKHR
    data::NTuple{64, UInt8}
end

# to see the layout
function Base.getproperty(x::Ptr{VkAccelerationStructureInstanceKHR}, f::Symbol)
    f === :transform && return Ptr{VkTransformMatrixKHR}(x + 0)
    f === :instanceCustomIndex && return Ptr{UInt32}(x + 48)
    f === :mask && return Ptr{UInt32}(x + 51)
    f === :instanceShaderBindingTableRecordOffset && return Ptr{UInt32}(x + 52)
    f === :flags && return Ptr{VkGeometryInstanceFlagsKHR}(x + 55)
    f === :accelerationStructureReference && return Ptr{UInt64}(x + 56)
    return getfield(x, f)
end

# generated code

function VkAccelerationStructureInstanceKHR(transform::VkTransformMatrixKHR, instanceCustomIndex::UInt32, mask::UInt32, instanceShaderBindingTableRecordOffset::UInt32, flags::VkGeometryInstanceFlagsKHR, accelerationStructureReference::UInt64)
    ref = Ref{VkAccelerationStructureInstanceKHR}()
    ptr = Base.unsafe_convert(Ptr{VkAccelerationStructureInstanceKHR}, ref)
    ptr.transform = transform
    ptr.instanceCustomIndex = instanceCustomIndex
    ptr.mask = mask
    ptr.instanceShaderBindingTableRecordOffset = instanceShaderBindingTableRecordOffset
    ptr.flags = flags
    ptr.accelerationStructureReference = accelerationStructureReference
    ref[]
end
```