### PR TITLE
Support separating common and API file

### DIFF
--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -14,6 +14,11 @@ library_names = {}
 # output file path relative to the working directory
 output_file_path = "../lib/LibClang.jl"
 
+# if these are set, common file (types and constants) and API file (functions) will be seperated
+# this is for compatibility, so prologue and epilogue are not supported.
+# output_api_file_path = "api.jl"
+# output_common_file_path = "common.jl"
+
 # if this entry is not empty, the generator will print the code below to the `output_file_path`.
 # module module_name
 # 

--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -136,7 +136,9 @@ function create_context(headers::Vector, args::Vector=String[], options::Dict=Di
             push!(ctx.passes, StdPrinter())
         end
     else
-        # TODO: impl
+        # let the user handle prologue and epilogue on their own
+        push!(ctx.passes, FunctionPrinter(api_file))
+        push!(ctx.passes, CommonPrinter(common_file))
     end
 
     return ctx

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -871,7 +871,7 @@ function (x::CommonPrinter)(dag::ExprDAG, options::Dict)
     open(x.file, "w") do io
         for node in dag.nodes
             string(node.id) ∈ blacklist && continue
-            node.type isa AbstractMacroNodeType && continue
+            (node.type isa AbstractMacroNodeType || node.type isa AbstractFunctionNodeType) && continue
             pretty_print(io, node, general_options)
         end
         # print macros in the bottom of the file


### PR DESCRIPTION
This PR enables support for supporting the old behavior of separating common and API files. 
Tested in https://github.com/SciML/Sundials.jl/pull/322.