### PR TITLE
Support dumping enum as integer constants

### DIFF
--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -62,6 +62,10 @@ use_julia_native_enum_type = false
 # this is useful in the case of using `CEnum` directly in the source tree instead of using `CEnum` as a dependency
 print_using_CEnum = true
 
+# Print enums directly as integers without @(c)enum wrapper
+# Override above two options
+print_enum_as_integer = false
+
 # use deterministic symbol instead of `gensym`-generated `var"##XXX"`
 use_deterministic_symbol = true
 

--- a/src/generator/jltypes.jl
+++ b/src/generator/jltypes.jl
@@ -26,11 +26,12 @@ end
 JuliaCrecord() = JuliaCrecord(Symbol())
 JuliaCrecord(x::AbstractString) = JuliaCrecord(Symbol(x), getNullCursor())
 
-struct JuliaCenum <: AbstractJuliaType
+struct JuliaCenum{T<:CLCursor} <: AbstractJuliaType
     sym::Symbol
+    cursor::T
 end
 JuliaCenum() = JuliaCenum(Symbol())
-JuliaCenum(x::AbstractString) = JuliaCenum(Symbol(x))
+JuliaCenum(x::AbstractString) = JuliaCenum(Symbol(x), getNullCursor())
 
 struct JuliaCtypedef <: AbstractJuliaType
     sym::Symbol
@@ -151,7 +152,10 @@ end
 tojulia(x::CLInvalid) = JuliaUnknown(x)
 tojulia(x::CLFunctionProto) = JuliaCfunction(spelling(getTypeDeclaration(x)))
 tojulia(x::CLFunctionNoProto) = JuliaCfunction(spelling(getTypeDeclaration(x)))
-tojulia(x::CLEnum) = JuliaCenum(spelling(getTypeDeclaration(x)))
+function tojulia(x::CLEnum)
+    c = getTypeDeclaration(x)
+    JuliaCenum(Symbol(spelling(c)), c)
+end
 function tojulia(x::CLRecord)
     c = getTypeDeclaration(x)
     JuliaCrecord(Symbol(spelling(c)), c)

--- a/src/generator/print.jl
+++ b/src/generator/print.jl
@@ -179,6 +179,7 @@ function pretty_print(io, node::ExprNode{<:AbstractEnumNodeType}, options::Dict)
     @assert !isempty(node.exprs)
     use_native_enum = get(options, "use_julia_native_enum_type", false)
     enumerator_comment_style = get(options, "enumerator_comment_style", "disable")
+    enum_as_integer = get(options, "print_enum_as_integer", false)
     members = enumerator_comment_style == "outofline"
     enum_values = Dict()
 
@@ -188,7 +189,7 @@ function pretty_print(io, node::ExprNode{<:AbstractEnumNodeType}, options::Dict)
     prologue = ["    $(head_expr.args[1])", ""]
     print_documentation(io, node, "", options, members; prologue)
 
-    if length(node.exprs) ≥ 2
+    if length(node.exprs) ≥ 2 && !enum_as_integer
         enum_macro = use_native_enum ? "@enum" : "@cenum"
         println(io, "$enum_macro $head_expr begin")
         child_nodes = filter(x->x isa CLEnumConstantDecl, children(node.cursor))
@@ -210,6 +211,11 @@ function pretty_print(io, node::ExprNode{<:AbstractEnumNodeType}, options::Dict)
         # for empty enums, we make it an alias of the corresponding integer type
         enum_name, int_ty = head_expr.args
         println(io, "const $enum_name = $int_ty")
+        for ex in Iterators.drop(node.exprs, 1)
+            @assert Meta.isexpr(ex, :(=))
+            lhs, rhs = ex.args
+            println(io, :(const $lhs = $rhs % $int_ty))
+        end
     end
     println(io)
 

--- a/src/generator/print.jl
+++ b/src/generator/print.jl
@@ -210,7 +210,7 @@ function pretty_print(io, node::ExprNode{<:AbstractEnumNodeType}, options::Dict)
     else
         # for empty enums, we make it an alias of the corresponding integer type
         enum_name, int_ty = head_expr.args
-        println(io, "const $enum_name = $int_ty")
+        println(io, :(const $enum_name = $int_ty))
         for ex in Iterators.drop(node.exprs, 1)
             @assert Meta.isexpr(ex, :(=))
             lhs, rhs = ex.args


### PR DESCRIPTION
This PR reuses the old path that emits enum as an alias for integer type.
The second commit made enum carry necessary information for further analysis, but my trial to use it did not succeed. Should I keep this?