### PR TITLE
add an exclusivity list to output options

### DIFF
--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -58,9 +58,6 @@ output_ignorelist = [
     "LLVM_CLANG_C_EXTERN_C_END"
 ]
 
-# Only output id in the `output_exclusivelist"
-# output_output_exclusivelist = []
-
 # Julia's `@enum` do not allow duplicated values, so by default, C enums are translated to 
 # CEnum.jl's `@cenum`. 
 # if this entry is true, `@enum` is used and those duplicated enum constants are just commented. 

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -58,6 +58,9 @@ output_ignorelist = [
     "LLVM_CLANG_C_EXTERN_C_END"
 ]
 
+# Only output id in the `output_exclusivelist"
+# output_output_exclusivelist = []
+
 # Julia's `@enum` do not allow duplicated values, so by default, C enums are translated to 
 # CEnum.jl's `@cenum`. 
 # if this entry is true, `@enum` is used and those duplicated enum constants are just commented. 


### PR DESCRIPTION
If this list is given, only symbols in the list will be output.

If this is deemed an ok idea, I can add tests etc.