### PR TITLE
strip trailing whitespace in generated docstrings

### DIFF
--- a/src/generator/documentation.jl
+++ b/src/generator/documentation.jl
@@ -243,13 +243,11 @@ function format_doxygen(cursor, options, members=false)
         push!(lines, "### Parameters")
         for p in parameters
             append!(lines, format_parameter(p, options))
-            push!(lines, "")
         end
     end
     if !ismissing(returns)
         push!(lines, "### Returns")
         append!(lines, format_block(Clang.getParagraph(returns), options))
-        push!(lines, "")
     end
     if !isempty(member_docs)
         append!(lines, member_docs)

--- a/src/generator/documentation.jl
+++ b/src/generator/documentation.jl
@@ -264,6 +264,7 @@ function format_parameter(p, options)
     name = Clang.getParamName(p)
     dir = parameter_pass_direction_name(Clang.getDirection(p))
     content = format_inline.(children(p), Ref(options))
+    content[end] = rstrip(content[end])
     ["* `$name`:$dir$(content[1])"; @view content[2:end]]
 end
 

--- a/src/generator/documentation.jl
+++ b/src/generator/documentation.jl
@@ -283,8 +283,8 @@ end
 
 function format_block(x::Clang.Paragraph, options)
     t = format_inline(x, options)
-    # Remove leading space
-    t = replace(t, r"^\s+"=>"")
+    # Remove leading and trailing whitespace
+    t = strip(t)
     [t]
 end
 


### PR DESCRIPTION
And also remove remove empty lines in Parameters or Returns lists. Though it could be that I don't understand the reason those need to be there. The markdown format doesn't require them.

- remove trailing whitespace for Clang.Paragraph
see the effect in https://github.com/JuliaGeo/Proj4.jl/commit/04b9fb8136ea1821bca8c370de59e4bfeabffe9b
- remove empty lines in Parameters or Returns lists
see the effect in https://github.com/JuliaGeo/Proj4.jl/commit/fc126ae7e6f7a3b2fb51c96eba15c7d189054847
- strip trailing whitespace after parameter
see the effect in https://github.com/JuliaGeo/Proj4.jl/commit/7830d54720c3154e3062a7e6841af35a3256290d
