### PR TITLE
Generators: Add padding between non consecutive fields

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -304,8 +304,17 @@ getCursorResultType(c::Union{CLFunctionDecl,CLCXXMethod})::CLType = clang_getCur
 
 ## TODO:
 # clang_getCursorExceptionSpecificationType
-# clang_Cursor_getOffsetOfField
 #
+
+"""
+    getOffsetOfField(c::Union{CXCursor,CLCursor}) -> Int
+Return the offset of the field represented by the cursor in bits as it
+would be returned by __offsetof__ as per C++11[18.2p4].
+
+It returns a minus number for layout errors, please convert the result to
+a [`CXTypeLayoutError`](@ref) to see what the error is.
+"""
+getOffsetOfField(c::Union{CXCursor,CLCursor})::Int = clang_Cursor_getOffsetOfField(c)
 
 """
     isAnonymous(c::Union{CXCursor,CLCursor}) -> Bool

--- a/src/generator/Generators.jl
+++ b/src/generator/Generators.jl
@@ -24,6 +24,7 @@ using ..Clang:
     getNumArguments,
     getNumElements,
     getOffsetOf,
+    getOffsetOfField,
     getPointeeType,
     getSizeOf,
     getTranslationUnit,


### PR DESCRIPTION
Hello :wave:

I had an issue with Clang.jl where the created Julia struct would not match the C representation of the same struct because of field alignments issues.

Consider the following struct:

```c
struct B {
  uint64_t ba;
  uint64_t bb;
};

union union_B {
  struct B b;
};

struct A {
  char a;
  union union_B b;
};

/**/
sizeof(struct A) // 24
sizeof(struct B) // 16
sizeof(struct A) != sizeof(char) + sizeof(struct B) // true
```

The generated Julia struct is:

```julia
struct B
  ba::UInt64
  bb::UInt64
end

struct union_B
    data::NTuple{16, UInt8}
end

struct A
  a::Cchar
  b::union_B
end

#==#
sizeof(A) # 17
sizeof(union_B) # 16
sizeof(A) != sizeof(Cchar) + sizeof(union_B) # false
```

The C and Julia version of field `b::B` are not aligned (C is `+8` whereas Julia is only `+1`). This PR tries to address this problem by adding new fields on the Julia side and adding a custom constructor to the struct:

```julia
struct B
  ba::UInt64
  bb::UInt64
end

struct union_B
    data::NTuple{16, UInt8}
end

struct A
    a::Cchar
    var"##pad0#274"::NTuple{7, UInt8}
    b::union_B
    A(a, b) = new(a, Tuple((zero(UInt8) for _ = 1:7)), b)
end

#==#
sizeof(A) # 24
sizeof(union_B) # 16
sizeof(A) != sizeof(Cchar) + sizeof(union_B) # true
```

I have noticed that there are only a few tests for `Clang.Generators` so I would be interested on having other codebase to test this code on. For example when generating the Julia for `clang-c` into LibClang some struct are added padding fields. Also, should I add test for this ? It would eval the generated julia code and check the different `sizeof`.

Anyway, thanks for making this project!