### PR TITLE
feat(JLLEnvs): try to load local Artifacts.toml if existed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CEnum = "0.4"


### PR DESCRIPTION
Almost certainly I get network issues when `using Clang` in China unless I set proxies. This PR works around it so I figured people might want to see this change.

```
julia> using Clang
ERROR: InitError: Failed to connect to raw.githubusercontent.com port 443: Connection refused while requesting https://raw.githubusercontent.com/JuliaPackaging/BinaryBuilderBase.jl/master/Artifacts.toml
```

---

This commit provides two changes:

- By default, use the stable release version of `Artifacts.toml` provided by
  binarybuilderbase. previously it uses the master version, which can sometimes
  be breaking and troublesome.
- it utilizes the local disk cache and thus pkg server so that we don't need to
  fetch resources from GitHub.com and thus is more friendly to users behind the
  firewall.

As a consequence of getting rid of the need to download from remote server,
this commit makes `@time using Clang` much faster: from 1.7s to 0.4s in Julia
1.7, macOS Intel i9-9880H.