### PR TITLE
add support for ignore by regex

### DIFF
--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -852,11 +852,11 @@ end
 
 function should_exclude_node(node, ignoreregex, ignorelist, exclusivelist)
     str_node = string(node.id)
-    for re in ignoreregex
+    for re ∈ ignoreregex
         match(re, str_node) === nothing || return true
     end
     str_node ∈ ignorelist && return true
-    if exclusivelist !== nothing && !(str_node in exclusivelist)
+    if exclusivelist !== nothing && str_node ∉ exclusivelist
         return true
     end
     return false

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -852,8 +852,8 @@ end
 
 function should_exclude_node(node, ignorelist, exclusivelist)
     str_node = string(node.id)
-    for re ∈ ignorelist
-        match(re, str_node) === nothing || return true
+    for item ∈ ignorelist
+        match(Regex(item), str_node) === nothing || return true
     end
     if exclusivelist !== nothing && str_node ∉ exclusivelist
         return true
@@ -881,7 +881,7 @@ function (x::FunctionPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "FunctionPrinter_log", x.show_info)
-    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
+    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     show_info && @info "[FunctionPrinter]: print to $(x.file)"
@@ -909,7 +909,7 @@ function (x::CommonPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "CommonPrinter_log", x.show_info)
-    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
+    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     show_info && @info "[CommonPrinter]: print to $(x.file)"
@@ -943,7 +943,7 @@ function (x::GeneralPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "GeneralPrinter_log", x.show_info)
-    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
+    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
     general_options["DAG_ids"] = merge(dag.ids, dag.tags)
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
@@ -980,7 +980,7 @@ function (x::StdPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "StdPrinter_log", x.show_info)
-    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
+    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     for node in dag.nodes

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -850,12 +850,11 @@ function (x::Audit)(dag::ExprDAG, options::Dict)
     return dag
 end
 
-function should_exclude_node(node, ignoreregex, ignorelist, exclusivelist)
+function should_exclude_node(node, ignorelist, exclusivelist)
     str_node = string(node.id)
-    for re ∈ ignoreregex
+    for re ∈ ignorelist
         match(re, str_node) === nothing || return true
     end
-    str_node ∈ ignorelist && return true
     if exclusivelist !== nothing && str_node ∉ exclusivelist
         return true
     end
@@ -882,14 +881,13 @@ function (x::FunctionPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "FunctionPrinter_log", x.show_info)
-    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
-    ignoreregex = Regex.(get(general_options, "output_ignoreregex", []))
+    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     show_info && @info "[FunctionPrinter]: print to $(x.file)"
     open(x.file, "w") do io
         for node in dag.nodes
-            should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+            should_exclude_node(node, ignorelist, exclusivelist) && continue
             node.type isa AbstractFunctionNodeType || continue
             pretty_print(io, node, general_options)
         end
@@ -911,20 +909,19 @@ function (x::CommonPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "CommonPrinter_log", x.show_info)
-    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
-    ignoreregex = Regex.(get(general_options, "output_ignoreregex", []))
+    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     show_info && @info "[CommonPrinter]: print to $(x.file)"
     open(x.file, "w") do io
         for node in dag.nodes
-            should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+            should_exclude_node(node, ignorelist, exclusivelist) && continue
             (node.type isa AbstractMacroNodeType || node.type isa AbstractFunctionNodeType) && continue
             pretty_print(io, node, general_options)
         end
         # print macros in the bottom of the file
         for node in dag.nodes
-            should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+            should_exclude_node(node, ignorelist, exclusivelist) && continue
             node.type isa AbstractMacroNodeType || continue
             pretty_print(io, node, options)
         end
@@ -946,21 +943,20 @@ function (x::GeneralPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "GeneralPrinter_log", x.show_info)
-    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
-    ignoreregex = Regex.(get(general_options, "output_ignoreregex", []))
+    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
     general_options["DAG_ids"] = merge(dag.ids, dag.tags)
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     show_info && @info "[GeneralPrinter]: print to $(x.file)"
     open(x.file, "a") do io
         for node in dag.nodes
-            should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+            should_exclude_node(node, ignorelist, exclusivelist) && continue
             node.type isa AbstractMacroNodeType && continue
             pretty_print(io, node, general_options)
         end
         # print macros in the bottom of the file
         for node in dag.nodes
-            should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+            should_exclude_node(node, ignorelist, exclusivelist) && continue
             node.type isa AbstractMacroNodeType || continue
             isempty(node.exprs)
             pretty_print(io, node, options)
@@ -984,18 +980,17 @@ function (x::StdPrinter)(dag::ExprDAG, options::Dict)
     general_options = get(options, "general", Dict())
     log_options = get(general_options, "log", Dict())
     show_info = get(log_options, "StdPrinter_log", x.show_info)
-    ignorelist = get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", []))
-    ignoreregex = Regex.(get(general_options, "output_ignoreregex", []))
+    ignorelist = Regex.(get(general_options, "output_ignorelist", get(general_options, "printer_blacklist", [])))
     exclusivelist = get(general_options, "output_exclusivelist", nothing)
 
     for node in dag.nodes
-        should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+        should_exclude_node(node, ignorelist, exclusivelist) && continue
         node.type isa AbstractMacroNodeType && continue
         pretty_print(stdout, node, general_options)
     end
     # print macros
     for node in dag.nodes
-        should_exclude_node(node, ignoreregex, ignorelist, exclusivelist) && continue
+        should_exclude_node(node, ignorelist, exclusivelist) && continue
         node.type isa AbstractMacroNodeType || continue
         pretty_print(stdout, node, options)
     end


### PR DESCRIPTION
I'm trying to generate `MPI` signatures in https://github.com/JuliaParallel/MPI.jl/pull/644.

It would be convenient to filter output by regex, since `output_ignorelist` requires listing everything by hand (and this would take more time than writing this PR).

E.g. this works in my `generator.toml`:
```
output_ignoreregex = ["^PMPI_", "^QMPI_"]
```