### PR TITLE
Unix C library compatibility

### DIFF
--- a/src/generator/audit.jl
+++ b/src/generator/audit.jl
@@ -73,7 +73,7 @@ function sanity_check(dag::ExprDAG, options::Dict)
         elseif is_function(idn)
             ifile, iline, icol = get_file_line_column(idn.cursor)
             tfile, tline, tcol = get_file_line_column(tn.cursor)
-            error("sanity check failed. [REASON]: use the same name $tk for struct $(tn.cursor) at $tfile:$tline:$tcol and function $(idn.cursor) at $ifile:$iline:$icol. The C code use the same name for structs and functions, which is not a good code-style, please fix it in the upstream.")
+            @warn "sanity check failed. [REASON]: use the same name $tk for struct $(tn.cursor) at $tfile:$tline:$tcol and function $(idn.cursor) at $ifile:$iline:$icol. The C code use the same name for structs and functions, which is not a good code-style, please fix it in the upstream."
         else
             error("sanity check failed. please file an issue to Clang.jl.")
         end

--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -87,9 +87,10 @@ function emit!(dag::ExprDAG, node::ExprNode{FunctionProto}, options::Dict; args.
     use_ccall_macro = get(options, "use_ccall_macro", false)
     if use_ccall_macro
         name_type_pairs = [Expr(:(::), n, t) for (n, t) in zip(arg_names, args)]
+        library_func = library_expr == nothing ? func_name : :($library_expr.$func_name)
         body = Expr(:macrocall, Symbol("@ccall"), nothing,
                     Expr(:(::), Expr(:call,
-                                        :($library_expr.$func_name),
+                                        library_func,
                                         name_type_pairs...,
                                     ),
                          ret_type

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -32,7 +32,15 @@ function (x::CollectTopLevelNode)(dag::ExprDAG, options::Dict)
         header_name = normpath(spelling(tu_cursor))
         @info "Processing header: $header_name"
         for cursor in children(tu_cursor)
-            file_name = normpath(get_filename(cursor))
+            file_name = get_filename(cursor)
+
+            # Ignore items where no source file is available.
+            # e.g. built-in defines like `__llvm__` and `__clang__`.
+            if !is_local_only && isempty(file_name)
+                continue
+            end
+
+            file_name = normpath(file_name)
             if is_local_only && header_name != file_name && file_name ∉ x.dependent_headers
                 if any(sysdir -> startswith(file_name, sysdir), x.system_dirs)
                     collect_top_level_nodes!(dag.sys, cursor, general_options)


### PR DESCRIPTION
Changes to enable wrapping of the system C library on mac OS and Linux.

See commit logs for detail.

Currently I am wrapping: `<errno.h>`, `<string.h>`, `<limits.h>`, `<stdlib.h>`, `<pthread.h>`, `<sys/ioctl.h>`, `<termios.h>`, `<fcntl.h>`, `<poll.h>`, `<sys/epoll.h>` `<unistd.h>`, `<sys/stat.h>`, `<net/if.h>`, `<sys/socket.h>`, `<signal.h>`, `<sys/wait.h>`, `<sys/syscall.h>` and `<spawn.h>`.

... and i'm using these options:
```julia
   Dict{String,Any}(
            "general" => Dict{String,Any}(
                "is_local_header_only" => false,
                "auto_mutability" => true,
                "auto_mutability_includelist" => ["termios"],
                "library_name" => ""
            ),
            "codegen" => Dict{String,Any}(
                "use_ccall_macro" => true,
                "wrap_variadic_function" => false
            ),
            "codegen.macro" => Dict{String,Any}(
                "macro_mode" => "aggressive",
                "ignore_pure_definition" => true
            )
        )
```

See https://github.com/notinaboat/UnixIO.jl/blob/c03f1695999666ab95177b5e1713e2fe1cd1eae0/packages/UnixIOHeaders/src/UnixIOHeaders.jl#L162-L188  