### PR TITLE
Bug fix in output_ignorelist

### DIFF
--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -865,7 +865,10 @@ end
 function should_exclude_node(node, ignorelist, exclusivelist)
     str_node = string(node.id)
     for item ∈ ignorelist
-        match(Regex(item), str_node) === nothing || return true
+        the_match = match(Regex(item), str_node)
+        if the_match !== nothing  && the_match.match == str_node
+            return true
+        end
     end
     if exclusivelist !== nothing && str_node ∉ exclusivelist
         return true


### PR DESCRIPTION
With the current behavior, a node is skipped if its id contains the regex listed in `output_ignorelist`. For example, in this header file:
```c
typedef int ThisIsALongNameWithXSomewhereInIt;
typedef int X;
```
if `output_ignorelist` contains `"X"`, then neither symbol will be output.

Instead, it should be checked that the entire id matches the regex (and if the other behavior is desired, this can be accomplished with explicit wildcards, `".*X.*"`).