### PR TITLE
Add a pass for linking enum aliases in the `no_audit` mode

### DIFF
--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -108,8 +108,10 @@ function create_context(headers::Vector, args::Vector=String[], options::Dict=Di
     if get(general_options, "smart_de_anonymize", true)
         push!(ctx.passes, DeAnonymize())
     end
-    if !get(general_options, "no_audit", false)
-        @error "The generator is running in `no_audit` mode. It could generate invalid Julia code. Please DO NOT submit issues only occur in this mode. You can remove the `no_audit` entry in the `.toml` file to exit this mode."
+    if get(general_options, "no_audit", false)
+        @error "The generator is running in `no_audit` mode. It could generate invalid Julia code. You can remove the `no_audit` entry in the `.toml` file to exit this mode."
+        get(general_options, "link_enum_alias", true) && push!(ctx.passes, LinkEnumAlias())
+    else
         push!(ctx.passes, Audit())
     end
     push!(ctx.passes, Codegen())

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -153,3 +153,9 @@ end
     ctx = create_context([joinpath(@__DIR__, "include/enum.h")], get_default_args())
     @test_throws Exception build!(ctx)
 end
+
+@testset "Issue 412 - no audit" begin
+    options = Dict("general" => Dict{String,Any}("no_audit" => true))
+    ctx = create_context([joinpath(@__DIR__, "include/enum.h")], get_default_args(), options)
+    @test_logs (:info, "Done!") match_mode = :any build!(ctx)
+end


### PR DESCRIPTION
fix #412

cc @VarLad