### PR TITLE
Move `_cxstring_to_string` out of `cursor.jl`.

### DIFF
--- a/src/Clang.jl
+++ b/src/Clang.jl
@@ -24,6 +24,8 @@ foreach(names(@__MODULE__; all=true)) do s
     end
 end
 
+include("string.jl")
+
 include("index.jl")
 export Index
 

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -18,15 +18,6 @@ Base.hash(x::CLCursor) = hash(x.cursor)
 Base.:(==)(c1::CLCursor, c2::CXCursor) = c1.cursor == c2
 Base.:(==)(c1::CXCursor, c2::CLCursor) = c1 == c2.cursor
 
-"Free and convert a CXString to String. Note this function will free the given CXString so ensure it is not called twice."
-function _cxstring_to_string(cxstr::CXString)
-    ptr = clang_getCString(cxstr)
-    ptr == C_NULL && return ""
-    s = unsafe_string(ptr)
-    clang_disposeString(cxstr)
-    return s
-end
-
 """
     kind(c::CXCursor) -> CXCursorKind
 Return the kind of the given cursor.

--- a/src/string.jl
+++ b/src/string.jl
@@ -1,0 +1,8 @@
+"Free and convert a CXString to String. Note this function will free the given CXString so ensure it is not called twice."
+function _cxstring_to_string(cxstr::CXString)
+    ptr = clang_getCString(cxstr)
+    ptr == C_NULL && return ""
+    s = unsafe_string(ptr)
+    clang_disposeString(cxstr)
+    return s
+end


### PR DESCRIPTION
Will simplify upcoming modules.jl and files.jl PRs