### PR TITLE
Cleanup CXFile support and add unique_id

### DIFF
--- a/src/Clang.jl
+++ b/src/Clang.jl
@@ -33,6 +33,9 @@ end
 
 include("string.jl")
 
+include("file.jl")
+export CLFile, name, unique_id, get_filename
+
 include("index.jl")
 export Index
 
@@ -41,6 +44,7 @@ export TranslationUnit, spelling, parse_header, parse_headers
 
 include("cursor.jl")
 export kind, name, spelling, value
+export file, file_line_column
 export get_filename, get_file_line_column, get_function_args
 export is_typedef_anon, is_forward_declaration, is_inclusion_directive
 export search, children

--- a/src/file.jl
+++ b/src/file.jl
@@ -1,0 +1,38 @@
+struct CLFile
+    file::CXFile
+end
+
+Base.convert(::Type{CLFile}, x::CXFile) = CLFile(x)
+Base.cconvert(::Type{CXFile}, x::CLFile) = x
+Base.unsafe_convert(::Type{CXFile}, x::CLFile) = x.file
+
+Base.show(io::IO, x::CLFile) = print(io, """CLFile ("$(name(x))")""")
+
+
+"""
+    get_filename(x::CXFile) -> String
+Return the complete file and path name of the given file
+"""
+function get_filename(file::CXFile)
+    name(CLFile(file))
+end
+
+
+"""
+    name(x::CLFile) -> String
+Return the complete file and path name of the given file
+"""
+function name(file::CLFile)
+    file |> clang_getFileName |> _cxstring_to_string
+end
+
+"""
+    unique_id(file::CLFile) -> CXFileUniqueID
+Return the unique id of the given file.
+"""
+function unique_id(file::CLFile)
+    id = Ref{CXFileUniqueID}()
+    ret = clang_getFileUniqueID(file, id)
+    @assert ret==0 "Error getting unique id for $file"
+    id[]
+end

--- a/src/platform/system.jl
+++ b/src/platform/system.jl
@@ -78,8 +78,8 @@ function get_system_includes!(env::MacEnv, prefix::String, isys::Vector{String})
                   joinpath(prefix, triple, "sys-root", "System", "Library", "Frameworks"))
         end
     else  # "aarch64-apple-darwin20"
+        ver = VersionNumber(version.major,version.minor,version.patch)
         if env.is_cxx
-            ver = VersionNumber(version.major,version.minor,version.patch)
             push!(isys, joinpath(prefix, triple, "include", "c++", string(ver)))
             push!(isys, joinpath(prefix, triple, "include", "c++", string(ver), triple))
             push!(isys, joinpath(prefix, triple, "include", "c++", string(ver), "backward"))

--- a/test/file.jl
+++ b/test/file.jl
@@ -1,0 +1,51 @@
+using Clang
+using Test
+
+@testset "File" begin
+
+@testset "Null File" begin
+    @test name(CLFile(C_NULL))  == ""
+end
+
+@testset "Cursor filename" begin
+    mktempdir() do dir
+        header = joinpath(dir,"test.h")
+        open(header, "w") do io
+            write(io, "void foo();")
+        end
+        index = Index()
+        tu = parse_header(index, header)
+        fname = tu |> Clang.getTranslationUnitCursor |> children |> 
+                      only |> file |> name |> normpath
+        @test fname == header |> normpath
+    end
+end
+
+@testset "Unique ID" begin
+    @test_throws AssertionError unique_id(CLFile(C_NULL)) 
+    mktempdir() do dir
+        header = joinpath(dir,"test.h")
+        open(header, "w") do io
+            println(io, "void foo();")
+        end
+        a = joinpath(dir,"a.h")
+        open(a, "w") do io
+            println(io, "#include \"test.h\"")
+        end
+
+        b = joinpath(dir,"b.h")
+        open(b, "w") do io
+            println(io, "#include \"test.h\"")
+        end
+
+        index = Index()
+        tu_a = parse_header(index, a)
+        tu_b = parse_header(index, b)
+        cu_a = tu_a |> Clang.getTranslationUnitCursor |> children |> only 
+        cu_b = tu_b |> Clang.getTranslationUnitCursor |> children |> only 
+        @test (cu_a |> file |> unique_id) === (cu_b |> file |> unique_id) 
+    end
+
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
 # https://github.com/JuliaLang/julia/issues/52986
 using REPL
 
+include("file.jl")
 include("generators.jl")
 
 include("test_mpi.jl")


### PR DESCRIPTION
This is somewhat invasive, but hopefully not too scary. 

It will help for adding support for modules which are uniqued by their ast file. I included the commit from #423 which is pretty simple.  I can close that PR if you  take this onn or I can rebase this one later. 