### PR TITLE
Deprecate `getCanonicalType(c::CXCursor)` 

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -402,9 +402,6 @@ getCanonicalCursor(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
 @deprecate getCanonicalType(c::CXCursor) getCanonicalCursor(c::CXCursor)
 @deprecate getCanonicalType(c::CLCursor) getCanonicalCursor(c::CLCursor)
 
-getCanonicalType(c::CXCursor) = clang_getCanonicalCursor(c)
-getCanonicalType(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
-
 ## TODO:
 # clang_Cursor_getObjCSelectorIndex
 # clang_Cursor_isDynamicCall

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -403,9 +403,6 @@ getCanonicalCursor(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
 getCanonicalType(c::CXCursor) = clang_getCanonicalCursor(c)
 getCanonicalType(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
 
-"""
-    getCursorKind(c::Union{CXCursor,CLCursor}) -> CXCursorKind
-
 ## TODO:
 # clang_Cursor_getObjCSelectorIndex
 # clang_Cursor_isDynamicCall

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -392,12 +392,19 @@ Return true if the declaration pointed to by this cursor is also a definition of
 isCursorDefinition(c::Union{CXCursor,CLCursor})::Bool = clang_isCursorDefinition(c)
 
 """
-    getCanonicalType(c::CXCursor) -> CXCursor
-    getCanonicalType(c::CLCursor) -> CLCursor
-Return the getCanonicalType cursor corresponding to the given cursor.
+    getCanonicalCursor(c::CXCursor) -> CXCursor
+    getCanonicalCursor(c::CLCursor) -> CLCursor
+Return the getCanonicalCursor cursor corresponding to the given cursor.
 """
+getCanonicalCursor(c::CXCursor) = clang_getCanonicalCursor(c)
+getCanonicalCursor(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
+
+@deprecate getCanonicalType getCanonicalCursor
 getCanonicalType(c::CXCursor) = clang_getCanonicalCursor(c)
 getCanonicalType(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
+
+"""
+    getCursorKind(c::Union{CXCursor,CLCursor}) -> CXCursorKind
 
 ## TODO:
 # clang_Cursor_getObjCSelectorIndex

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -399,7 +399,9 @@ Return the getCanonicalCursor cursor corresponding to the given cursor.
 getCanonicalCursor(c::CXCursor) = clang_getCanonicalCursor(c)
 getCanonicalCursor(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
 
-@deprecate getCanonicalType getCanonicalCursor
+@deprecate getCanonicalType(c::CXCursor) getCanonicalCursor(c::CXCursor)
+@deprecate getCanonicalType(c::CLCursor) getCanonicalCursor(c::CLCursor)
+
 getCanonicalType(c::CXCursor) = clang_getCanonicalCursor(c)
 getCanonicalType(c::CLCursor)::CLCursor = clang_getCanonicalCursor(c)
 


### PR DESCRIPTION
it should be `getCanonicalCursor(c::CXCursor)`.