### PR TITLE
Fix cycle removal bugs

### DIFF
--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -543,7 +543,7 @@ function emit!(dag::ExprDAG, node::ExprNode{StructMutualRef}, options::Dict; arg
 
             if node_idx < field_idx
                 # this assumes that circular references were removed at pointers
-                @assert is_jl_pointer(jlty)
+                @assert is_jl_pointer(jlty) "Expected this field to be a pointer: $(struct_sym).$(field_sym)"
 
                 # also emit the original expressions, so we can add corresponding comments
                 # in the pretty-print pass

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -383,6 +383,10 @@ function (x::RemoveCircularReference)(dag::ExprDAG, options::Dict)
                         dag.nodes[nc] = ExprNode(id, ty, child.cursor, child.exprs, child.adj)
                         show_info &&
                             @info "[RemoveCircularReference]: removed $(child.id)'s dependency $(parent.id)"
+
+                        # Now the cycle is broken and we don't need to look at
+                        # any other nodes in the cycle path.
+                        break
                     end
                 end
                 # exit earlier
@@ -405,8 +409,9 @@ function (x::RemoveCircularReference)(dag::ExprDAG, options::Dict)
                     dag.nodes[nc] = ExprNode(id, ty, child.cursor, child.exprs, child.adj)
                     show_info &&
                         @info "[RemoveCircularReference]: removed $(child.id)'s dependency $(parent.id)"
+
                     # exit earlier
-                    (node_idx + 1) == first(cycle) && break
+                    break
                 end
             end
 

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -361,10 +361,10 @@ function (x::RemoveCircularReference)(dag::ExprDAG, options::Dict)
     count = 0
     while any(x -> x != PERMANENT, marks) && (count += 1) < MAX_CIRCIR_DETECTION_COUNT
         fill!(marks, UNMARKED)
-        for (i, node) in enumerate(dag.nodes)
-            marks[i] == UNMARKED || continue
+        for (node_idx, node) in enumerate(dag.nodes)
+            marks[node_idx] == UNMARKED || continue
             cycle = Int[]
-            detect_cycle!(dag.nodes, marks, cycle, i)
+            detect_cycle!(dag.nodes, marks, cycle, node_idx)
             isempty(cycle) && continue
 
             # firstly remove cycle reference caused by mutually referenced structs
@@ -386,7 +386,7 @@ function (x::RemoveCircularReference)(dag::ExprDAG, options::Dict)
                     end
                 end
                 # exit earlier
-                (i + 1) == first(cycle) && break
+                (node_idx + 1) == first(cycle) && break
             end
 
             # there are cases where the circular reference can only be de-referenced at a
@@ -406,7 +406,7 @@ function (x::RemoveCircularReference)(dag::ExprDAG, options::Dict)
                     show_info &&
                         @info "[RemoveCircularReference]: removed $(child.id)'s dependency $(parent.id)"
                     # exit earlier
-                    (i + 1) == first(cycle) && break
+                    (node_idx + 1) == first(cycle) && break
                 end
             end
 

--- a/test/include/cycle-detection.h
+++ b/test/include/cycle-detection.h
@@ -1,0 +1,32 @@
+typedef struct A A;
+typedef struct B B;
+typedef struct C C;
+
+struct B;
+struct C;
+
+struct B
+{
+    B* x;
+};
+
+struct C
+{
+    B y[10];
+};
+
+typedef struct vector_C
+{
+    C* c;
+} vector_C;
+
+typedef struct pool_C
+{
+    vector_C vc;
+} pool_C;
+
+struct A
+{
+    pool_C pc;
+    C* c;
+};


### PR DESCRIPTION
The `i` index in the outermost loop over the nodes would become shadowed by the `i` index in the inner loop over the cycle indices, so the check to exit early would be done against the wrong variable.

I don't have an example of this failing, I was just reading the code and figured that it was probably a bug. Unfortunately I'm not familiar enough with the code to write a test for it.