### PR TITLE
Add support for Doxygen's @deprecated command

### DIFF
--- a/src/generator/documentation.jl
+++ b/src/generator/documentation.jl
@@ -310,6 +310,7 @@ function format_block(x::Clang.BlockCommand, options)
     name in ["li", "arg"] && return ["* $content"]
     name in ["brief", "details"] && return [content]
     name in ["note", "warning"] && return ["!!! $name", "", "    $content"]
+    name in ["deprecated"] && return ["!!! compat \"Deprecated\"", "", "    $content"]
     ["\\$name$args $content"]
 end
 

--- a/test/include/documentation.h
+++ b/test/include/documentation.h
@@ -1,0 +1,14 @@
+/**
+ * @brief Dummy function.
+ *
+ * @param foo           A parameter.
+ *
+ * @return              Whatever I want.
+ *
+ * @see quux()
+ *
+ * @deprecated This function is evil.
+ */
+void doxygen_func(int foo) {
+    return 0;
+}


### PR DESCRIPTION
Also added a simple test for the documentation parser.

---

Before:
![image](https://github.com/JuliaInterop/Clang.jl/assets/5361518/3d5b1710-d1dd-440e-afd1-0dd00720541d)

After:
![image](https://github.com/JuliaInterop/Clang.jl/assets/5361518/3e0551f3-864d-45be-ae38-19587b07df46)