### PR TITLE
Add support for Doxygen's @bug command

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,8 +7,8 @@ Changelog](https://keepachangelog.com).
 
 ### Added
 
-- Doxygens `@deprecated` command will now be translated to a `!!! compat`
-  admonition ([#460]).
+- Doxygens `@deprecated` and `@bug` commands will now be translated to `!!!
+  compat` and `!!! danger` admonitions, respectively ([#460], [#463]).
 
 ### Breaking
 

--- a/src/generator/documentation.jl
+++ b/src/generator/documentation.jl
@@ -306,6 +306,7 @@ function format_block(x::Clang.BlockCommand, options)
     name in ["brief", "details"] && return [content]
     name in ["note", "warning"] && return ["!!! $name", "", "    $content"]
     name in ["deprecated"] && return ["!!! compat \"Deprecated\"", "", "    $content"]
+    name in ["bug"] && return ["!!! danger \"Known bug\"", "", "    $content"]
     ["\\$name$args $content"]
 end
 

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -237,6 +237,7 @@ end
         @test docstring_has(" * `foo`: A parameter")
         @test docstring_has("### Returns")
         @test docstring_has("Whatever I want")
+        @test docstring_has("!!! danger \"Known bug\"")
         @test docstring_has("### See also")
         @test docstring_has("quux()")
         @test docstring_has("callback")

--- a/test/include/documentation.h
+++ b/test/include/documentation.h
@@ -5,6 +5,8 @@
  *
  * @return              Whatever I want.
  *
+ * @bug May wipe your disk.
+ *
  * @see quux()
  *
  * @deprecated This function is evil.


### PR DESCRIPTION
Now they're displayed as a `!!! danger` admonition.

---

Before:
![image](https://github.com/JuliaInterop/Clang.jl/assets/5361518/e137d60a-1dba-42b2-a797-baafbce2051a)

After:
![image](https://github.com/JuliaInterop/Clang.jl/assets/5361518/eea4c47a-4873-4ab0-8805-2935f1c3b39b)
