### PR TITLE
Use the concrete RefValue type to avoid method ambiguities

### DIFF
--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -241,7 +241,7 @@ function emit!(dag::ExprDAG, node::ExprNode{TypedefMutualRef}, options::Dict; ar
         # in the method signature (which is necessary to avoid a method
         # ambiguity with Base). Hence we add it to `node.premature_exprs` to be
         # used later when the struct itself is emitted.
-        lhs = Expr(:call, :(Base.unsafe_convert), :(::Type{Ptr{$fake_sym}}), :(x::Ref{$real_sym}))
+        lhs = Expr(:call, :(Base.unsafe_convert), :(::Type{Ptr{$fake_sym}}), :(x::Base.RefValue{$real_sym}))
         rhs = :(Base.unsafe_convert(Ptr{$fake_sym}, Base.unsafe_convert(Ptr{$real_sym}, x)))
         push!(node.premature_exprs, :($lhs = $rhs))
         # make sure the behavior remains the same for `Ptr`

--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -256,7 +256,7 @@ function emit!(dag::ExprDAG, node::ExprNode{TypedefMutualRef}, options::Dict; ar
         push!(node.exprs, :(const $typedef_sym = $typedefee))
 
         # Record this node as only partially emitted
-        dag.partial_nodes[real_sym] = node
+        dag.partially_emitted_nodes[real_sym] = node
     end
     return dag
 end
@@ -521,11 +521,11 @@ function emit!(dag::ExprDAG, node::ExprNode{<:AbstractStructNodeType}, options::
     end
 
     # Emit any existing premature expressions
-    if haskey(dag.partial_nodes, struct_sym)
-        partial_node = dag.partial_nodes[struct_sym]
+    if haskey(dag.partially_emitted_nodes, struct_sym)
+        partial_node = dag.partially_emitted_nodes[struct_sym]
         append!(node.exprs, partial_node.premature_exprs)
         empty!(partial_node.premature_exprs)
-        delete!(dag.partial_nodes, struct_sym)
+        delete!(dag.partially_emitted_nodes, struct_sym)
     end
 
     return dag

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -741,8 +741,8 @@ function (x::Codegen)(dag::ExprDAG, options::Dict)
     end
 
     # Make sure that all nodes have been fully emitted
-    if !isempty(dag.partial_nodes)
-        error("Codegen error, these nodes have not been fully emitted: $(keys(dag.partial_nodes))")
+    if !isempty(dag.partially_emitted_nodes)
+        error("Codegen error, these nodes have not been fully emitted: $(keys(dag.partially_emitted_nodes))")
     end
 
     # clean up

--- a/src/generator/types.jl
+++ b/src/generator/types.jl
@@ -178,7 +178,7 @@ An expression DAG.
 """
 Base.@kwdef struct ExprDAG
     nodes::Vector{ExprNode} = ExprNode[]
-    partial_nodes::Dict{Symbol, ExprNode} = Dict{Symbol, ExprNode}()
+    partially_emitted_nodes::Dict{Symbol, ExprNode} = Dict{Symbol, ExprNode}()
     sys::Vector{ExprNode} = ExprNode[]
     tags::Dict{Symbol,Int} = Dict{Symbol,Int}()
     ids::Dict{Symbol,Int} = Dict{Symbol,Int}()


### PR DESCRIPTION
On 1.11 there's a new `unsafe_convert(::Type{Ptr{T}}, a::GenericMemoryRef)` method which causes ambiguity errors with just Ref in the `unsafe_convert()` methods we define, so now we use the concrete RefValue.

This fixes ambiguity warnings from Aqua.jl, e.g:
```julia
2 ambiguities found
Ambiguity #1
unsafe_convert(::Type{Ptr{LibSSH.lib.__JL_sftp_packet_struct}}, x::Ref{LibSSH.lib.sftp_packet_struct}) @ LibSSH.lib ~/work/LibSSH.jl/LibSSH.jl/src/bindings.jl:2685
unsafe_convert(::Type{Ptr{T}}, a::GenericMemoryRef) where T @ Base pointer.jl:90

Possible fix, define
  unsafe_convert(::Type{Ptr{LibSSH.lib.__JL_sftp_packet_struct}}, ::GenericMemoryRef{isatomic, LibSSH.lib.sftp_packet_struct} where isatomic)
```

I also renamed the `partial_nodes` field to `partially_emitted_nodes` for clarity in ab0b3d5.