### PR TITLE
Print explicit import for using CEnum

### DIFF
--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -1119,7 +1119,7 @@ function (x::ProloguePrinter)(dag::ExprDAG, options::Dict)
 
         # print "using CEnum"
         if !use_native_enum && print_CEnum
-            println(io, "using CEnum")
+            println(io, "using CEnum: CEnum, @cenum")
             println(io)
         end
 


### PR DESCRIPTION
With the `print_using_CEnum` option equal `true`, an implicit import for `CEnum` is produced by printing `using CEnum`. However, then https://github.com/ericphanson/ExplicitImports.jl complains about the implicit import. It would be nice if `@cenum` (and probably also `CEnum`) would be imported explicitly. Since `@cenum` is the only exported name by CEnum.jl this approach should not break anything. Correct me if I am wrong.