### PR TITLE
Add support for function-like macros in the auditors sanity checks

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,8 @@ Changelog](https://keepachangelog.com).
 
 - The generator will now explicitly import the symbols from `CEnum` it uses to
   avoid implicit imports ([#488]).
+- Added support to the auditor for detecting structs and function-like macros of
+  the same name, which previously caused the generator to crash ([#500]).
 
 ## [v0.18.3] - 2024-04-23
 

--- a/src/generator/types.jl
+++ b/src/generator/types.jl
@@ -205,6 +205,9 @@ is_anonymous(::ExprNode{<:Union{StructAnonymous,UnionAnonymous,EnumAnonymous}}) 
 is_function(::ExprNode) = false
 is_function(::ExprNode{<:AbstractFunctionNodeType}) = true
 
+is_macrofunctionlike(::ExprNode) = false
+is_macrofunctionlike(::ExprNode{MacroFunctionLike}) = true
+
 is_variadic_function(::ExprNode) = false
 is_variadic_function(::ExprNode{FunctionVariadic}) = true
 

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -97,6 +97,12 @@ end
     @test node.exprs[3].head == :(=)
 end
 
+@testset "Sanity checking" begin
+    ctx = create_context(joinpath(@__DIR__, "include/sanity-checks.h"), get_default_args())
+    @test_logs (:warn, r"function-like macro .* foo") match_mode = :any build!(ctx)
+    @test_logs (:warn, r"function .* post") match_mode = :any build!(ctx)
+end
+
 @testset "Issue 320" begin
     args = get_default_args()
     dir = joinpath(@__DIR__, "sys")

--- a/test/include/sanity-checks.h
+++ b/test/include/sanity-checks.h
@@ -1,0 +1,11 @@
+#define foo(x) ((int)(x))
+
+struct foo {
+    char c;
+};
+
+struct post {
+    char m;
+};
+
+void post(struct post m);


### PR DESCRIPTION
Fixes #499. The problem is that in [one of the headers](https://github.com/lexbor/lexbor/blob/master/source/lexbor/css/syntax/token.h) there are macros with the same names as struct types, e.g.:
```c
// Line 29
#define lxb_css_syntax_token_delim(token) ((lxb_css_syntax_token_delim_t *) (token))

// Line 139
typedef struct lxb_css_syntax_token_delim {
    lxb_css_syntax_token_base_t base;
    lxb_char_t                  character;
}
lxb_css_syntax_token_delim_t;
```

We already check for these kinds of conflicts between structs and functions, but not structs and macro-like functions so the auditor failed. I think this ought to be fixed upstream by changing the struct definitions to use untagged structs like so:
```c
typedef struct {
    lxb_css_syntax_token_base_t base;
    lxb_char_t                  character;
}
lxb_css_syntax_token_delim_t;
```