### PR TITLE
Short and Elaborated Enums

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -242,12 +242,14 @@ function value(c::CLEnumConstantDecl)::Integer
                      getCanonicalType |>
                      kind
     end
-    if typeKind == CXType_Int ||
+    if typeKind == CXType_Short ||
+        typeKind == CXType_Int ||
         typeKind == CXType_Long ||
         typeKind == CXType_LongLong ||
         typeKind == CXType_Char_S # enum : char
         return clang_getEnumConstantDeclValue(c)
-    elseif typeKind == CXType_UInt ||
+    elseif typeKind == CXType_UShort ||
+           typeKind == CXType_UInt ||
            typeKind == CXType_ULong ||
            typeKind == CXType_ULongLong ||
            typeKind == CXType_UChar

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -228,7 +228,7 @@ Return the integer value of an enum constant declaration.
 function value(c::CLEnumConstantDecl)::Integer
     typeKind = kind(getCursorType(c))
 
-    # PR ???
+    # PR 519
     if typeKind == CXType_Elaborated
         typeKind = getCursorType(c) |>
                     get_elaborated_cursor |>

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -227,6 +227,16 @@ Return the integer value of an enum constant declaration.
 """
 function value(c::CLEnumConstantDecl)::Integer
     typeKind = kind(getCursorType(c))
+
+    # PR ???
+    if typeKind == CXType_Elaborated
+        typeKind = getCursorType(c) |>
+                    get_elaborated_cursor |>
+                    getTypedefDeclUnderlyingType |>
+                    getCanonicalType |>
+                    kind
+    end
+
     # issue #404
     if typeKind == CXType_Typedef
         typeKind = getCursorType(c) |>

--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -668,6 +668,13 @@ const ENUM_SYMBOL2TYPE = Dict(
 function emit!(dag::ExprDAG, node::ExprNode{<:AbstractEnumNodeType}, options::Dict; args...)
     cursor = node.cursor
     ty = getEnumDeclIntegerType(cursor)
+
+    if ty isa Clang.CLElaborated
+        ty = get_elaborated_cursor(ty) |>
+             getTypedefDeclUnderlyingType |>
+             getCanonicalType
+    end
+
     if ty isa Clang.CLTypedef
         ty = getTypeDeclaration(ty) |>
              getTypedefDeclUnderlyingType |>

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -206,6 +206,11 @@ end
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)
 end
 
+@testset "PR 519 - Elaborated Enum" begin
+    ctx = create_context([joinpath(@__DIR__, "include/elaborateEnum.h")], get_default_args())
+    @test_logs (:info, "Done!") match_mode = :any build!(ctx)
+end
+
 @testset "Issue 452 - StructMutualRef" begin
     ctx = create_context([joinpath(@__DIR__, "include/struct-mutual-ref.h")], get_default_args())
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)

--- a/test/include/elaborateEnum.h
+++ b/test/include/elaborateEnum.h
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+enum X : uint32_t {
+  A = 2,
+  B = 4,
+  C = 6,
+};


### PR DESCRIPTION
Adds support for enums for shorts and aliased types. This is part of a series of PRs that will hopefully enable generating wrappers from ObjectiveC headers.