### PR TITLE
[NFC] Typo and outdated docstring fix

### DIFF
--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -190,7 +190,7 @@ function_argument_conflict_symbols = []
 add_record_constructors = []
 
 [codegen.macro]
-# it‘s highly recommended to set this entry to "basic".
+# it's highly recommended to set this entry to "basic".
 # if you'd like to skip all of the macros, please set this entry to "disable".
 # if you'd like to translate function-like macros to Julia, please set this entry to "aggressive".
 macro_mode = "basic"

--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -160,7 +160,7 @@ create_context(header::AbstractString, args=String[], ops=Dict()) = create_conte
 end
 
 """
-    build!(ctx::Context, skip_printing = true)
+    build!(ctx::Context, stage = BUILDSTAGE_ALL)
 Run all passes.
 """
 function build!(ctx::Context, stage=BUILDSTAGE_ALL)


### PR DESCRIPTION
Use the typical `'` and fixup an outdated docstring.