### PR TITLE
Properly skip `EnumForwardDecls` even with attributes

### DIFF
--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -635,20 +635,17 @@ function (x::CodegenPreprocessing)(dag::ExprDAG, options::Dict)
             dag.nodes[i] = ExprNode(node.id, skip_mode, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: skip a $(node.type) node named $(node.id)"
-        end
-        if attribute_check(dag, node)
+        elseif attribute_check(dag, node)
             ty = attribute_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: mark an attribute $(node.type) node named $(node.id)"
-        end
-        if nested_anonymous_check(dag, node)
+        elseif nested_anonymous_check(dag, node)
             ty = nested_anonymous_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: mark a nested anonymous $(node.type) node named $(node.id)"
-        end
-        if bitfield_check(dag, node)
+        elseif bitfield_check(dag, node)
             ty = bitfield_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -211,6 +211,26 @@ end
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)
 end
 
+@testset "PR 522 - Still skip EnumForwardDecl with attributes" begin
+    ctx = create_context([joinpath(@__DIR__, "include/elaborateEnum.h")], get_default_args())
+
+    mktemp() do path, io
+        redirect_stdout(io) do
+            build!(ctx)
+        end
+        close(io)
+
+        output = Ref{String}("")
+        open(path) do file
+            output[] = read(file, String)
+        end
+
+        print(output[])
+        @test contains(output[],"@cenum X::UInt32 begin") # Correctly output
+        @test !contains(output[], "const X = UInt32")     # const not output
+    end
+end
+
 @testset "Issue 452 - StructMutualRef" begin
     ctx = create_context([joinpath(@__DIR__, "include/struct-mutual-ref.h")], get_default_args())
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)

--- a/test/include/elaborateEnum.h
+++ b/test/include/elaborateEnum.h
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+typedef enum __attribute__((flag_enum,enum_extensibility(open))) X : uint32_t X;
 enum X : uint32_t {
   A = 2,
   B = 4,


### PR DESCRIPTION
MacOS ObjectiveC headers have enum forward declarations with attributes.

Currently, such a node gets marked as skip during `CodegenPreprocessing`:
https://github.com/JuliaInterop/Clang.jl/blob/572eddfbb30a30fdf2257ca7ec11a146380dbc6c/src/generator/passes.jl#L632-L638

but then it immediately gets replaced with an EnumLayout due to the next check checking the  original node:
https://github.com/JuliaInterop/Clang.jl/blob/572eddfbb30a30fdf2257ca7ec11a146380dbc6c/src/generator/passes.jl#L639-L644

I'm not sure if my fix is the intended behaviour, so it would be nice to have someone review it. Other solutions I consedered were adding a `continue` to the end of each check (or only to `skip_check`), or maybe instead of doing checks on the original node,  always check the newest.

Includes changes from #519.