### PR TITLE
Enable ObjectiveC framework enum and struct parsing

### DIFF
--- a/src/generator/context.jl
+++ b/src/generator/context.jl
@@ -90,6 +90,11 @@ function create_context(headers::Vector, args::Vector=String[], options::Dict=Di
     @info "Parsing headers..."
     parse_headers!(ctx, headers, args)
 
+    add_default_passes!(ctx, options, system_dirs, dependent_headers)
+end
+
+function add_default_passes!(ctx::AbstractContext, options::Dict, system_dirs::Vector, dependent_headers::Vector)
+
     push!(ctx.passes, CollectTopLevelNode(ctx.trans_units, dependent_headers, system_dirs))
     push!(ctx.passes, LinkTypedefToAnonymousTagType())
     push!(ctx.passes, LinkTypedefToAnonymousTagType(is_system=true))

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -635,20 +635,17 @@ function (x::CodegenPreprocessing)(dag::ExprDAG, options::Dict)
             dag.nodes[i] = ExprNode(node.id, skip_mode, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: skip a $(node.type) node named $(node.id)"
-        end
-        if attribute_check(dag, node)
+        elseif attribute_check(dag, node)
             ty = attribute_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: mark an attribute $(node.type) node named $(node.id)"
-        end
-        if nested_anonymous_check(dag, node)
+        elseif nested_anonymous_check(dag, node)
             ty = nested_anonymous_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&
                 @info "[CodegenPreprocessing]: mark a nested anonymous $(node.type) node named $(node.id)"
-        end
-        if bitfield_check(dag, node)
+        elseif bitfield_check(dag, node)
             ty = bitfield_type(node.type)
             dag.nodes[i] = ExprNode(node.id, ty, node.cursor, node.exprs, node.adj)
             show_info &&

--- a/src/generator/top_level.jl
+++ b/src/generator/top_level.jl
@@ -159,6 +159,23 @@ function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLEnumDecl, o
     return nodes
 end
 
+# TODO: Implement full ObjectiveC codegen
+function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLObjCClassRef, options)
+    return nodes
+end
+function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLObjCProtocolDecl, options)
+    return nodes
+end
+function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLObjCProtocolRef, options)
+    return nodes
+end
+function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLObjCInterfaceDecl, options)
+    return nodes
+end
+function collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLObjCCategoryDecl, options)
+    return nodes
+end
+
 # skip macro expansion since the expanded info is already embedded in the AST
 collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLMacroInstantiation, options) = nodes
 collect_top_level_nodes!(nodes::Vector{ExprNode}, cursor::CLMacroExpansion, options) = nodes

--- a/src/generator/types.jl
+++ b/src/generator/types.jl
@@ -147,7 +147,7 @@ struct EnumDuplicated <: AbstractEnumNodeType end
 struct EnumDefault <: AbstractEnumNodeType end
 
 """
-    EnumLayout{Attribute} <: AbstractStructNodeType
+    EnumLayout{Attribute} <: AbstractEnumNodeType
 Enum nodes that have special layout.
 """
 struct EnumLayout{Attribute} <: AbstractEnumNodeType end

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -211,6 +211,26 @@ end
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)
 end
 
+@testset "PR 522 - Still skip EnumForwardDecl with attributes" begin
+    ctx = create_context([joinpath(@__DIR__, "include/elaborateEnum.h")], get_default_args())
+
+    mktemp() do path, io
+        redirect_stdout(io) do
+            build!(ctx)
+        end
+        close(io)
+
+        output = Ref{String}("")
+        open(path) do file
+            output[] = read(file, String)
+        end
+
+        print(output[])
+        @test contains(output[],"@cenum X::UInt32 begin") # Correctly output
+        @test !contains(output[], "const X = UInt32")     # const not output
+    end
+end
+
 @testset "Issue 452 - StructMutualRef" begin
     ctx = create_context([joinpath(@__DIR__, "include/struct-mutual-ref.h")], get_default_args())
     @test_logs (:info, "Done!") match_mode = :any build!(ctx)

--- a/test/include/elaborateEnum.h
+++ b/test/include/elaborateEnum.h
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+typedef enum __attribute__((flag_enum,enum_extensibility(open))) X : uint32_t X;
 enum X : uint32_t {
   A = 2,
   B = 4,


### PR DESCRIPTION
Builds on/requires #522.

This PR (along with #519 and #522) are the minimal changes required to allow Metal.jl to autogenerate the enums and structs for our frameworks. See https://github.com/JuliaGPU/Metal.jl/pull/492

I had to split up `create_context` because we use the same passes, but could not use the first part up to and including the header parsing.