### PR TITLE
Work around #532

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,4 @@ using REPL
 
 include("ClangTests.jl")
 
-retest(Clang, ClangTests; stats=true)
+retest(Clang, ClangTests; stats=true, spin=false)


### PR DESCRIPTION
This seems to be an issue with running concurrent tests when the spinner is enabled. This PR deactivates the spinner. This closes #532 and makes the test output somewhat cleaner. 