### PR TITLE
Add hint to resolve cmake test failure

### DIFF
--- a/test/test_bitfield.jl
+++ b/test/test_bitfield.jl
@@ -34,7 +34,7 @@ function build_libbitfield()
     try
         # Compile binary
         if !build_libbitfield_native()
-            error("Could not build libbitfield binary")
+            error("Could not build libbitfield binary. Hint: Deleting `$(joinpath(@__DIR__, "build/"))` may resolve the issue.")
         end
 
         # Generate wrappers


### PR DESCRIPTION
Just spent a while trying to figure out why the LibBitField tests failed at the cmake compilation stage only to realize that `CMAKE_OSX_SYSROOT` pointed to the 15.1 macOS SDK while the SDK installed on my computer is 15.2.

This adds a hint to the error message to help out anyone else who encounters this in the future.