### PR TITLE
Add `Base.propertynames` function for union structs

### DIFF
--- a/test/include/anon-struct-in-anon-union.h
+++ b/test/include/anon-struct-in-anon-union.h
@@ -1,0 +1,10 @@
+typedef struct _PackedFloat3 {
+    union {
+        struct {
+            float x;
+            float y;
+            float z;
+        };
+        float elements[3];
+    };
+} PackedFloat3;


### PR DESCRIPTION
Closes #426