### PR TITLE
Update julia version used with Documenter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1.11'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.8'
+          version: '1.11'
       - run: |
           julia --project=docs -e '
             using Pkg


### PR DESCRIPTION
Documentation stopped building when support for Julia <= 1.10 was dropped.

We can stop specifying the version (riskier) or leave update it every update (more maintenance)