### PR TITLE
throw an error instead of falling back to `getfield` for `Ptr` types

### DIFF
--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -328,7 +328,7 @@ function emit_getproperty_ptr!(dag, node, options)
     signature = Expr(:call, :(Base.getproperty), :(x::Ptr{$sym}), :(f::Symbol))
     body = Expr(:block)
     _emit_getproperty_ptr!(body, node.cursor, node.cursor, options)
-    push!(body.args, :(return getfield(x, f)))
+    push!(body.args, :(throw(ArgumentError("$f is not a member of $(eltype(x))"))))
     getproperty_expr = Expr(:function, signature, body)
     push!(node.exprs, getproperty_expr)
     return dag


### PR DESCRIPTION
Hello,

The generated `Base.getproperty(x::Ptr{T}, f::Symbol)` emits a `getfield(x,f)` if all other cases are exhausted.
But `getfield` is not really defined for `Ptr` (which makes sense, since it doesn't have any field) and static analysis tools like `JET` generate a lot of noise about it.

What about throwing an exception instead? It shouldn't be breaking since we'd be throwing an exception anyway, and provides a better error message and makes analysis tools happy.
