### PR TITLE
Disable `CrashRecoveryContext` to preserve Julia signal handlers

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,4 @@ using REPL
 
 include("ClangTests.jl")
 
-retest(Clang, ClangTests; stats=true, spin=false)
+retest(Clang, ClangTests; stats=true)


### PR DESCRIPTION
Without this change, the following code reliably segfaults on my machine:
```julia
$ julia -t2 -q
julia> using Clang
julia> Clang.Index();

julia> Threads.@threads for i in 1:1000; zeros(1024, 1024) .+ zeros(1024, 1024); end
[3044] signal 11 (-6): Segmentation fault
```

LLVM's `CrashRecoveryContext` replaces all signal handlers and assumes that a SIGSEGV signal is fatal, which is incompatible with language runtimes like Julia / Java which use this signal as a hook for GC safepoints.

Sadly libclang does not provide any mechanism to disable this behavior (which affects the application globally), except via the "LIBCLANG_DISABLE_CRASH_RECOVERY" environment variable. Changing ENV on-the-fly like this is not thread-safe either, but it's the best we can do to avoid losing our signal handlers.

Resolves https://github.com/JuliaTesting/ReTest.jl/issues/61, which is due to the same problem.