### PR TITLE
Update generator script for Clang 20

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -3,6 +3,11 @@
 This documents notable changes in Clang.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Added
+- Added support for Clang 20 ([#550], [#551]).
+
 ## [v0.19.0] - 2025-08-14
 
 ### Added

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -2,3 +2,6 @@
 BinaryBuilderBase = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[sources]
+Clang = {path=".."}

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -64,7 +64,7 @@ cd(@__DIR__) do
                                           #=(v"15.0.6", v"1.10"),=#
                                           #=(v"16.0.6", v"1.11"),=#
                                           #=(v"18.1.7", v"1.12"),=#
-                                          (v"19.1.1", v"1.13"),)
+                                          (v"20.1.8", v"1.13"),)
         @info "Generating..." llvm_version julia_version
         temp_prefix() do prefix
             # let prefix = Prefix(mktempdir())


### PR DESCRIPTION
Also made the generator project refer to the local source so that it's easier to set the right compat bounds.

The Pkg issue in https://github.com/JuliaInterop/Clang.jl/pull/550#issuecomment-3202441750 seems to have been fixed on latest nightly.