### PR TITLE
Switch to Clang_unified_jll.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,17 @@
 name = "Clang"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.19.2"
+version = "0.19.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"
+Clang_unified_jll = "ffc816e1-ba66-5fa9-9ecc-bcc5cb19bea1"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 CEnum = "0.4, 0.5"
-Clang_jll = "16,17,18,19,20,21"
+Clang_unified_jll = "0.1"
 Downloads = "1.4"
 TOML = "1.0"
 julia = "1.11.0"

--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ Write a config file `generator.toml`:
 library_name = "libclang"
 output_file_path = "./LibClang.jl"
 module_name = "LibClang"
-jll_pkg_name = "Clang_jll"
+jll_pkg_name = "Clang_unified_jll"
 export_symbol_prefixes = ["CX", "clang_"]
 ```
 
 and a Julia script `generator.jl`:
 ```julia
 using Clang.Generators
-using Clang.LibClang.Clang_jll  # replace this with your jll package
+using Clang.LibClang.Clang_unified_jll  # replace this with your jll package
 
 cd(@__DIR__)
 
-include_dir = normpath(Clang_jll.artifact_dir, "include")
+include_dir = normpath(Clang_unified_jll.artifact_dir, "include")
 clang_dir = joinpath(include_dir, "clang-c")
 
 options = load_options(joinpath(@__DIR__, "generator.toml"))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -3,6 +3,12 @@
 This documents notable changes in Clang.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v0.19.3] - 2026-03-03
+
+### Changed
+
+- Switch to Clang_unified_jll.jl for improved compatibility ([#563]).
+
 ## [v0.19.2] - 2026-02-25
 
 ### Fixed

--- a/docs/src/generator.md
+++ b/docs/src/generator.md
@@ -15,11 +15,11 @@ The general workflow of wrapping a JLL package is as follows.
 A generator context consists of a list of headers, a list of compiler flags, and generator options. The example below creates a typical context and runs the generator.
 ```julia
 using Clang.Generators
-using Clang.LibClang.Clang_jll
+using Clang.LibClang.Clang_unified_jll
 
 cd(@__DIR__)
 
-include_dir = normpath(Clang_jll.artifact_dir, "include")
+include_dir = normpath(Clang_unified_jll.artifact_dir, "include")
 
 # wrapper generator options
 options = load_options(joinpath(@__DIR__, "generator.toml"))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,7 +46,7 @@ The package includes a generator to create Julia wrappers for C libraries from a
 - macro: limited support
 - bitfield: experimental support
 
-The following example wraps `include/clang-c/*.h` from `Clang_jll` and prints the wrapper to `LibClang.jl`.
+The following example wraps `include/clang-c/*.h` from `Clang_unified_jll` and prints the wrapper to `LibClang.jl`.
 
 First write a configuration script `generator.toml`.
 ```toml
@@ -54,17 +54,17 @@ First write a configuration script `generator.toml`.
 library_name = "libclang"
 output_file_path = "./LibClang.jl"
 module_name = "LibClang"
-jll_pkg_name = "Clang_jll"
+jll_pkg_name = "Clang_unified_jll"
 export_symbol_prefixes = ["CX", "clang_"]
 ```
 Then load the configurations and generate a wrapper.
 ```julia
 using Clang.Generators
-using Clang.LibClang.Clang_jll
+using Clang.LibClang.Clang_unified_jll
 
 cd(@__DIR__)
 
-include_dir = normpath(Clang_jll.artifact_dir, "include")
+include_dir = normpath(Clang_unified_jll.artifact_dir, "include")
 clang_dir = joinpath(include_dir, "clang-c")
 
 # wrapper generator options

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,5 +1,5 @@
 using Clang.Generators
-using Clang.LibClang.Clang_jll
+using Clang.LibClang.Clang_unified_jll
 
 
 options = load_options(joinpath(@__DIR__, "generator.toml"))

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -28,7 +28,7 @@ module_name = "LibClang"
 # if this entry is not empty, the generator will print the code below to the `output_file_path`.
 # using jll_pkg_name
 # export jll_pkg_name
-jll_pkg_name = "Clang_jll"
+jll_pkg_name = "Clang_unified_jll"
 
 # for packages that have extra JLL package dependencies
 jll_pkg_extra = []

--- a/lib/16/LibClang.jl
+++ b/lib/16/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum
 

--- a/lib/17/LibClang.jl
+++ b/lib/17/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum
 

--- a/lib/18/LibClang.jl
+++ b/lib/18/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum
 

--- a/lib/19/LibClang.jl
+++ b/lib/19/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum
 

--- a/lib/20/LibClang.jl
+++ b/lib/20/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum: CEnum, @cenum
 

--- a/lib/21/LibClang.jl
+++ b/lib/21/LibClang.jl
@@ -1,7 +1,7 @@
 module LibClang
 
-using Clang_jll
-export Clang_jll
+using Clang_unified_jll
+export Clang_unified_jll
 
 using CEnum: CEnum, @cenum
 

--- a/src/Clang.jl
+++ b/src/Clang.jl
@@ -82,7 +82,7 @@ function version()
 end
 
 const LLVM_VERSION = match(r"[0-9]+.[0-9]+.[0-9]+", version()).match
-const LLVM_DIR = normpath(joinpath(dirname(LibClang.Clang_jll.libclang_path), ".."))
+const LLVM_DIR = normpath(joinpath(dirname(LibClang.Clang_unified_jll.libclang_path), ".."))
 const LLVM_LIBDIR = joinpath(LLVM_DIR, "lib")
 const LLVM_INCLUDE = joinpath(LLVM_LIBDIR, "clang", LLVM_VERSION, "include")
 const CLANG_INCLUDE = LLVM_INCLUDE

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -1,12 +1,12 @@
 using Clang
 using Clang.Generators
-using Clang.LibClang.Clang_jll
+using Clang.LibClang.Clang_unified_jll
 using Clang.Generators: StructDefinition, StructMutualRef, strip_comment_markers
 
 include("rewriter.jl")
 
 @testset "Generators" begin
-    INCLUDE_DIR = normpath(Clang_jll.artifact_dir, "include")
+    INCLUDE_DIR = normpath(Clang_unified_jll.artifact_dir, "include")
     CLANG_C_DIR = joinpath(INCLUDE_DIR, "clang-c")
 
     options = load_options(joinpath(@__DIR__, "test.toml"))

--- a/test/test.toml
+++ b/test/test.toml
@@ -1,7 +1,7 @@
 [general]
 library_name = "libclang"
 module_name = "LibClang"
-jll_pkg_name = "Clang_jll"
+jll_pkg_name = "Clang_unified_jll"
 extract_c_comment = "doxygen"
 fold_single_line_comment = true
 export_symbol_prefixes = ["CX", "clang_"]


### PR DESCRIPTION
Clang_jll has a couple of issues:
- each Julia version requires a different Clang_jll version, generating unnecesary churn when switching Julia versions.
- Clang_jll only works correctly if the compat entries in General are correct, which they often aren't, e.g., right now Clang_jll v21 gets installed on Julia 1.14 despite it only using LLVM v20.

Fix this by switching to a unified JLL that uses platform augmentations to select a compatible artifact based on whatever LLVM version was detected.