### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -12,9 +12,9 @@ isNull(c::Union{CXCursor,CLCursor}) = clang_Cursor_isNull(c) != 0
 
 # equality
 Base.:(==)(c1::CXCursor, c2::CXCursor)::Bool = clang_equalCursors(c1, c2)
-Base.hash(c::CXCursor)::UInt = clang_hashCursor(c)
+Base.hash(c::CXCursor, h::UInt) = hash(clang_hashCursor(c), h)
 Base.:(==)(c1::CLCursor, c2::CLCursor) = c1.cursor == c2.cursor
-Base.hash(x::CLCursor) = hash(x.cursor)
+Base.hash(x::CLCursor, h::UInt) = hash(x.cursor, h)
 Base.:(==)(c1::CLCursor, c2::CXCursor) = c1.cursor == c2
 Base.:(==)(c1::CXCursor, c2::CLCursor) = c1 == c2.cursor
 


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.