### PR TITLE
Add proper support for C division in macros

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -3,6 +3,13 @@
 This documents notable changes in Clang.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Added
+
+- Added proper support for divisions in C macros for integer and floating point
+  values ([#567]).
+
 ## [v0.19.3] - 2026-03-03
 
 ### Changed

--- a/src/generator/macro.jl
+++ b/src/generator/macro.jl
@@ -134,7 +134,26 @@ function normalize_literal(text)
     end
 end
 
-normalize_punctuation(text) = text == "/" ? "÷" : text == "^" ? "⊻" : text
+# C's `/` does integer division for integer operands and float division for
+# floats.  Julia's `÷` always does integer division. We use the `⧷` operator for
+# convenience to replace the existing `/` infix operator.
+const CDIV_DEFINITION = """
+# C-compatible division operator: integer division for integer types, float division for float types
+⧷(x::T, y::T) where {T <: Integer} = div(x, y)
+⧷(x::T, y::T) where {T <: AbstractFloat} = x / y
+⧷(x, y) = (⧷)(promote(x, y)...)
+"""
+
+function normalize_punctuation(dag::ExprDAG, text)
+    if text == "/"
+        push!(dag.prologue_defs, CDIV_DEFINITION)
+        return "⧷"
+    elseif text == "^"
+        return "⊻"
+    else
+        return text
+    end
+end
 
 is_literal(tok::CLToken) = tok.kind == CXToken_Literal
 is_identifier(tok::CLToken) = tok.kind == CXToken_Identifier
@@ -170,7 +189,7 @@ function tweak_exprs(dag::ExprDAG, toks::Vector)
             i += 1
         elseif is_punctuation(tok)
             if !isempty(tok.text)
-                push!(new_toks, Punctuation(DUMMY_TOKEN, CXToken_Punctuation, normalize_punctuation(tok.text)))
+                push!(new_toks, Punctuation(DUMMY_TOKEN, CXToken_Punctuation, normalize_punctuation(dag, tok.text)))
             end
             i += 1
         elseif is_keyword(tok)

--- a/src/generator/passes.jl
+++ b/src/generator/passes.jl
@@ -1001,6 +1001,9 @@ function (x::CommonPrinter)(dag::ExprDAG, options::Dict)
 
     show_info && @info "[CommonPrinter]: print to $(x.file)"
     open(x.file, "w") do io
+        for def in dag.prologue_defs
+            println(io, def)
+        end
         for node in dag.nodes
             should_exclude_node(node, ignorelist, exclusivelist, isystem_ignorelist) && continue
             (node.type isa AbstractMacroNodeType || node.type isa AbstractFunctionNodeType) && continue
@@ -1040,6 +1043,9 @@ function (x::GeneralPrinter)(dag::ExprDAG, options::Dict)
 
     show_info && @info "[GeneralPrinter]: print to $(x.file)"
     open(x.file, "a") do io
+        for def in dag.prologue_defs
+            println(io, def)
+        end
         for node in dag.nodes
             should_exclude_node(node, ignorelist, exclusivelist, isystem_ignorelist) && continue
             node.type isa AbstractMacroNodeType && continue
@@ -1078,6 +1084,9 @@ function (x::StdPrinter)(dag::ExprDAG, options::Dict)
     isystem_ignorelist = []
     !get(general_options, "generate_isystem_symbols", true) && append!(isystem_ignorelist, string(x.id) for x in dag.sys)
 
+    for def in dag.prologue_defs
+        println(stdout, def)
+    end
     for node in dag.nodes
         should_exclude_node(node, ignorelist, exclusivelist, isystem_ignorelist) && continue
         node.type isa AbstractMacroNodeType && continue

--- a/src/generator/types.jl
+++ b/src/generator/types.jl
@@ -198,6 +198,7 @@ Base.@kwdef struct ExprDAG
     tags::Dict{Symbol,Int} = Dict{Symbol,Int}()
     ids::Dict{Symbol,Int} = Dict{Symbol,Int}()
     ids_extra::Dict{Symbol,AbstractJuliaType} = EXTRA_DEFINITIONS
+    prologue_defs::Set{String} = Set{String}()
 end
 
 get_nodes(x::ExprDAG) = x.nodes

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -416,6 +416,23 @@ end
     end
 end
 
+# See https://github.com/JuliaInterop/Clang.jl/issues/556
+@testset "Issue 556 - division operator" begin
+    mktemp() do path, io
+        options = Dict("general" => Dict{String, Any}("output_file_path" => path))
+        ctx = create_context(joinpath(@__DIR__, "include/division.h"),
+                             get_default_args(), options)
+        build!(ctx)
+
+        m = Module()
+        Base.include(m, path)
+
+        @test @invokelatest(m.UNITS_PX) === 72f0 / 96f0
+        @test @invokelatest(m.INT_RATIO) === div(10, 3)
+        @test @invokelatest(m.NO_DIV) === 1 + 2
+    end
+end
+
 @testset "parse_headers()" begin
     # Mostly a test of the do-method
     mktempdir() do d

--- a/test/include/division.h
+++ b/test/include/division.h
@@ -1,0 +1,3 @@
+#define UNITS_PX (72.f / 96.0f)
+#define INT_RATIO (10 / 3)
+#define NO_DIV (1 + 2)


### PR DESCRIPTION
Implemented by adding a new `prologue_defs` field to `ExprDAG` for passes to add strings. The prologue definitions will then be printed at the top of the output file.

Fixes #556.