### PR TITLE
ObjectiveC: Don't add 'immutable' flag.

### DIFF
--- a/src/generator/codegen.jl
+++ b/src/generator/codegen.jl
@@ -927,7 +927,7 @@ end
     end
 
     # @objcwrapper
-    wrapperexpr = Expr(:macrocall, Symbol("@objcwrapper"), nothing, Expr(:(=), :immutable, :true))
+    wrapperexpr = Expr(:macrocall, Symbol("@objcwrapper"), nothing)
 
     # add availability attribute before type declaration
     if !isnothing(platform_availability) && !isnothing(minsupported) && convert(VersionNumber, platform_availability.Introduced) > minsupported

--- a/test/generators.jl
+++ b/test/generators.jl
@@ -251,11 +251,11 @@ end
         end
 
         print(output[])
-        @test contains(output[],"@objcwrapper immutable = true TestProtocol <: NSObject") # Protocol
-        @test contains(output[],"@objcwrapper immutable = true TestProtocol2 <: TestProtocol") # Protocol subtyping Protocol
-        @test contains(output[],"@objcwrapper immutable = true TestInterface <: NSObject") # Interface
+        @test contains(output[],"@objcwrapper TestProtocol <: NSObject") # Protocol
+        @test contains(output[],"@objcwrapper TestProtocol2 <: TestProtocol") # Protocol subtyping Protocol
+        @test contains(output[],"@objcwrapper TestInterface <: NSObject") # Interface
 
-        @test contains(output[],"@objcwrapper immutable = true availability = macos(v\"100.11.0\") TestAvailability <: NSObject") # Wrapper Availability
+        @test contains(output[],"@objcwrapper availability = macos(v\"100.11.0\") TestAvailability <: NSObject") # Wrapper Availability
         @test contains(output[],"@autoproperty length::Int32 availability = macos(v\"101.11.0\")") # Property Availability
 
         # Interface Properties


### PR DESCRIPTION
With https://github.com/JuliaInterop/ObjectiveC.jl/pull/80, the default behavior is preferable.

cc @christiangnrd 